### PR TITLE
remove debug banner

### DIFF
--- a/metaci/templates/layout_full.html
+++ b/metaci/templates/layout_full.html
@@ -11,20 +11,6 @@
 
 {% block base_page_header %}
 
-{% block local_header %}
-{% if debug %}
-<div class="slds-notify_container">
-    <div class="slds-notify" role="alert">
-      <span class="slds-assistive-text">Info</span>
-
-      <div class="slds-notify__content">
-        <h2 class="slds-text-heading--small">DEVELOPING ON {{ request.META.HTTP_HOST }}</h2>
-      </div>
-    </div>
-</div>
-{% endif %}
-{% endblock %}
-
 <header class="slds-global-header_container ">
   <div class="slds-global-header slds-grid slds-grid--align-spread ">
     <div class="slds-global-header__item">


### PR DESCRIPTION
Not against the idea of the banner, but I can't click the header links with it there. Removing it until we get a better solution.

Fixes #96 