### PR TITLE
Log Heroku `X-Request-ID` header

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 # MIDDLEWARE CONFIGURATION
 # ------------------------------------------------------------------------------
 MIDDLEWARE = (
+    'log_request_id.middleware.RequestIDMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -309,3 +310,9 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAdminUser',
     ),
 }
+
+# log_request_id settings
+LOG_REQUEST_ID_HEADER = 'HTTP_X_REQUEST_ID'
+LOG_REQUESTS = True
+GENERATE_REQUEST_ID_IF_NOT_IN_HEADER = True
+REQUEST_ID_RESPONSE_HEADER = "X-Request-ID"

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -182,36 +182,45 @@ LOGGING = {
         }
     },
     'formatters': {
-        'standard': {
+        'logfmt': {
             'format': 'at=%(levelname)-8s request_id=%(request_id)s module=%(name)s %(message)s'
+        },
+        'simple': {
+            'format': 'at=%(levelname)-8s module=%(name)s msg=%(message)s'
         },
     },
     'handlers': {
+        'console_w_req': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'filters': ['request_id'],
+            'formatter': 'logfmt'
+        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'filters': ['request_id'],
-            'formatter': 'standard'
+            'formatter': 'simple'
         }
     },
     'loggers': {
         'django.db.backends': {
             'level': 'ERROR',
-            'handlers': ['console'],
+            'handlers': ['console_w_req'],
             'propagate': False,
         },
         'raven': {
             'level': 'DEBUG',
-            'handlers': ['console'],
+            'handlers': ['console_w_req'],
             'propagate': False,
         },
         'django.security.DisallowedHost': {
             'level': 'ERROR',
-            'handlers': ['console',],
+            'handlers': ['console_w_req',],
             'propagate': False,
         },
         'log_request_id.middleware': {
-            'handlers': ['console'],
+            'handlers': ['console_w_req'],
             'level': 'DEBUG',
             'propagate': False,
         },

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -215,6 +215,11 @@ LOGGING = {
             'level': 'DEBUG',
             'propagate': False,
         },
+        "rq.worker": {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        }
     },
 }
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -176,17 +176,22 @@ LOGGING = {
         'level': 'WARNING',
         'handlers': [],
     },
+    'filters': {
+        'request_id': {
+            '()': 'log_request_id.filters.RequestIDFilter'
+        }
+    },
     'formatters': {
-        'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s '
-                      '%(process)d %(thread)d %(message)s'
+        'standard': {
+            'format': '%(levelname)-8s [%(asctime)s] [%(request_id)s] %(name)s: %(message)s'
         },
     },
     'handlers': {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
-            'formatter': 'verbose'
+            'filters': ['request_id'],
+            'formatter': 'standard'
         }
     },
     'loggers': {
@@ -205,8 +210,14 @@ LOGGING = {
             'handlers': ['console',],
             'propagate': False,
         },
+        'log_request_id.middleware': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
     },
 }
+
 RAVEN_CONFIG = {}
 if SENTRY_DSN:
     RAVEN_CONFIG['DSN'] = SENTRY_DSN

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -166,9 +166,9 @@ CACHES = {
 }
 
 
-# Sentry Configuration
-SENTRY_DSN = env('DJANGO_SENTRY_DSN', default=None)
-SENTRY_CLIENT = env('DJANGO_SENTRY_CLIENT', default='raven.contrib.django.raven_compat.DjangoClient')
+# Logging configuration, heroku logfmt
+# 12FA logs to stdout only.
+# request_id injected into logstream for all lines
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
@@ -183,7 +183,7 @@ LOGGING = {
     },
     'formatters': {
         'standard': {
-            'format': '%(levelname)-8s [%(asctime)s] [%(request_id)s] %(name)s: %(message)s'
+            'format': 'at=%(levelname)-8s request_id=%(request_id)s module=%(name)s %(message)s'
         },
     },
     'handlers': {
@@ -217,6 +217,10 @@ LOGGING = {
         },
     },
 }
+
+# Sentry Configuration
+SENTRY_DSN = env('DJANGO_SENTRY_DSN', default=None)
+SENTRY_CLIENT = env('DJANGO_SENTRY_CLIENT', default='raven.contrib.django.raven_compat.DjangoClient')
 
 RAVEN_CONFIG = {}
 if SENTRY_DSN:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -68,10 +68,10 @@ honcho>=0.7.1
 
 # Django REST Framework
 djangorestframework==3.6.3
-
-# Django Filters
-django-filters==0.2.1
 djangorestframework-filters==0.10.2
 
 # Core API for DRF schema generation
 coreapi==2.3.3
+
+# log-request-id for X-Request-Id header
+django-log-request-id==1.3.2


### PR DESCRIPTION
Heroku provides an [X-Request-ID header](https://devcenter.heroku.com/articles/http-request-id) for every HTTP request to allow tracking the request from router to dyno. 

Using the base config from the above Heroku devcenter blog, added the django-log-request-id middleware to include the HTTP request ID in the logging context, [provide request IDs in the response](https://geemus.gitbooks.io/http-api-design/content/en/foundations/provide-request-ids-for-introspection.html), and [emit a log line for every http request](https://brandur.org/canonical-log-lines).

Live in mrbelvedere-staging.