### PR TITLE
pkorslug for repo

### DIFF
--- a/metaci/api/utils.py
+++ b/metaci/api/utils.py
@@ -1,0 +1,39 @@
+import re
+from rest_framework.generics import get_object_or_404
+
+
+class PkOrSlugMixin(object):
+    """
+    ViewSet Mixin that supports looking up an object by primary key
+    or slug field in the same url scheme/default router. if the kwarg
+    matches lookup_pk_regexp (defaults to \d+), search by lookup_field,
+    otherwise, search by lookup_slug_field.
+    """
+
+    # Override lookup_slug_field with the name of your string/uri slug field
+    lookup_slug_field = 'slug'
+    # default assumes django orm convention of pk.
+    lookup_field = 'pk'
+    # default assumes integer PKs
+    lookup_pk_regexp = r"^\d+$"
+    # default from the router made explicit
+    lookup_value_regexp = r'[^/.]+'
+
+    def get_object(self):
+        """ return the object based on pk or slug """
+        queryset = self.filter_queryset(self.get_queryset())
+
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        lookup_value = self.kwargs[lookup_url_kwarg]
+
+        filter_kwargs = {}
+        if re.match(self.lookup_pk_regexp, lookup_value):
+            filter_kwargs[self.lookup_field] = lookup_value
+        else:
+            filter_kwargs[self.lookup_slug_field] = lookup_value
+
+        # May raise a permission denied
+        obj = get_object_or_404(queryset, **filter_kwargs)
+        self.check_object_permissions(self.request, obj)
+
+        return obj

--- a/metaci/api/utils.py
+++ b/metaci/api/utils.py
@@ -1,7 +1,6 @@
 import re
 from rest_framework.generics import get_object_or_404
 
-
 class PkOrSlugMixin(object):
     """
     ViewSet Mixin that supports looking up an object by primary key

--- a/metaci/api/views/repository.py
+++ b/metaci/api/views/repository.py
@@ -1,24 +1,25 @@
-from django.shortcuts import render
 from metaci.api.serializers.repository import BranchSerializer
 from metaci.api.serializers.repository import RepositorySerializer
 from metaci.repository.filters import BranchFilter
 from metaci.repository.filters import RepositoryFilter
 from metaci.repository.models import Branch
 from metaci.repository.models import Repository
+from metaci.api.utils import PkOrSlugMixin
 from rest_framework import viewsets
 
 class BranchViewSet(viewsets.ModelViewSet):
     """
-    A viewset for viewing and editing user instances.
+    A viewset for viewing and editing Branch instances.
     """
     serializer_class = BranchSerializer
     queryset = Branch.objects.all()
     filter_class = BranchFilter
 
-class RepositoryViewSet(viewsets.ModelViewSet):
+class RepositoryViewSet(PkOrSlugMixin, viewsets.ModelViewSet):
     """
-    A viewset for viewing and editing user instances.
+    A viewset for viewing and editing Repo instances.
     """
     serializer_class = RepositorySerializer
     queryset = Repository.objects.all()
     filter_class = RepositoryFilter
+    lookup_slug_field = 'name'


### PR DESCRIPTION
adds a generic mixin for ViewSet that looks the object by a pkid *or* slug field.

lookup repo by 'name' because that's a urlsafe slug field already.

enables: https://mrbelvedereci.herokuapps.com/api/repos/Affiliations