### PR TITLE
Fix init args for *OrgConfig

### DIFF
--- a/metaci/cumulusci/keychain.py
+++ b/metaci/cumulusci/keychain.py
@@ -70,9 +70,9 @@ class MetaCIProjectKeychain(BaseProjectKeychain):
         org_config = json.loads(org.json)
 
         if org.scratch:
-            config = ScratchOrgConfig(org_config)
+            config = ScratchOrgConfig(org_config, org.name)
         else:
-            config = OrgConfig(org_config)
+            config = OrgConfig(org_config, org.name)
 
         # Attach the org model instance to the org config
         config.org = org

--- a/metaci/cumulusci/models.py
+++ b/metaci/cumulusci/models.py
@@ -30,7 +30,7 @@ class Org(models.Model):
     def get_org_config(self):
         org_config = json.loads(self.json)
 
-        return OrgConfig(org_config)
+        return OrgConfig(org_config, self.name)
 
     @property
     def lock_id(self):
@@ -84,7 +84,7 @@ class ScratchOrgInstance(models.Model):
 
         org_config = json.loads(self.json)
 
-        return ScratchOrgConfig(org_config)
+        return ScratchOrgConfig(org_config, self.org.name)
 
     def delete_org(self, org_config=None):
         if org_config is None:


### PR DESCRIPTION
CumulusCI 2.0.0 beta77 and higher changed the way OrgConfig and ScratchOrgConfig instances are initialized.  Previously, they only accepted one argument, the config dict, but now they require the config dict and the org name.  Pass org name anytime an OrgConfig or ScratchOrgConfig is initialized.