### PR TITLE
Fix datetime encoding issue with json

### DIFF
--- a/metaci/cumulusci/keychain.py
+++ b/metaci/cumulusci/keychain.py
@@ -6,12 +6,12 @@ from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import ServiceConfig
 from cumulusci.core.exceptions import ServiceNotConfigured
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from metaci.cumulusci.logger import init_logger
 from metaci.cumulusci.models import Org
 from metaci.cumulusci.models import ScratchOrgInstance
 from metaci.cumulusci.models import Service
 from metaci.cumulusci.utils import get_connected_app
-from metaci.cumulusci.utils import json_serial
 
 
 class MetaCIProjectKeychain(BaseProjectKeychain):
@@ -50,7 +50,7 @@ class MetaCIProjectKeychain(BaseProjectKeychain):
         except Service.DoesNotExist:
             service = Service(
                 name=service_name,
-                json=json.dumps(service_config.config),
+                json=json.dumps(service_config.config, cls=DjangoJSONEncoder),
             )
         service.save()
 
@@ -120,13 +120,14 @@ class MetaCIProjectKeychain(BaseProjectKeychain):
         return org_config
 
     def set_org(self, org_config):
+        org_json = json.dumps(org_config.config, cls=DjangoJSONEncoder)
         try:
             org = Org.objects.get(repo=self.build.repo, name=org_config.name)
-            org.json = json.dumps(org_config.config)
+            org.json = org_json
         except Org.DoesNotExist:
             org = Org(
                 name=org_config.name,
-                json=json.dumps(org_config.config, default=json_serial),
+                json=org_json,
                 repo=self.build.repo,
             )
 

--- a/metaci/cumulusci/keychain.py
+++ b/metaci/cumulusci/keychain.py
@@ -11,6 +11,7 @@ from metaci.cumulusci.models import Org
 from metaci.cumulusci.models import ScratchOrgInstance
 from metaci.cumulusci.models import Service
 from metaci.cumulusci.utils import get_connected_app
+from metaci.cumulusci.utils import json_serial
 
 
 class MetaCIProjectKeychain(BaseProjectKeychain):
@@ -125,9 +126,10 @@ class MetaCIProjectKeychain(BaseProjectKeychain):
         except Org.DoesNotExist:
             org = Org(
                 name=org_config.name,
-                json=json.dumps(org_config.config),
+                json=json.dumps(org_config.config, default=json_serial),
                 repo=self.build.repo,
             )
 
         org.scratch = isinstance(org_config, ScratchOrgConfig)
-        org.save()
+        if not org.scratch:
+            org.save()

--- a/metaci/cumulusci/utils.py
+++ b/metaci/cumulusci/utils.py
@@ -1,4 +1,3 @@
-from datetime import date, datetime
 from cumulusci.core.config import ConnectedAppOAuthConfig
 from django.conf import settings
 

--- a/metaci/cumulusci/utils.py
+++ b/metaci/cumulusci/utils.py
@@ -1,6 +1,7 @@
 from cumulusci.core.config import ConnectedAppOAuthConfig
 from django.conf import settings
 
+
 def get_connected_app():
     return ConnectedAppOAuthConfig({
         'callback_url': settings.CONNECTED_APP_CALLBACK_URL,

--- a/metaci/cumulusci/utils.py
+++ b/metaci/cumulusci/utils.py
@@ -1,6 +1,6 @@
+from datetime import date, datetime
 from cumulusci.core.config import ConnectedAppOAuthConfig
 from django.conf import settings
-
 
 def get_connected_app():
     return ConnectedAppOAuthConfig({
@@ -8,3 +8,11 @@ def get_connected_app():
         'client_id': settings.CONNECTED_APP_CLIENT_ID,
         'client_secret': settings.CONNECTED_APP_CLIENT_SECRET,
     })
+
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    raise TypeError ("Type %s not serializable" % type(obj))
+

--- a/metaci/cumulusci/utils.py
+++ b/metaci/cumulusci/utils.py
@@ -8,11 +8,3 @@ def get_connected_app():
         'client_id': settings.CONNECTED_APP_CLIENT_ID,
         'client_secret': settings.CONNECTED_APP_CLIENT_SECRET,
     })
-
-def json_serial(obj):
-    """JSON serializer for objects not serializable by default json code"""
-
-    if isinstance(obj, (datetime, date)):
-        return obj.isoformat()
-    raise TypeError ("Type %s not serializable" % type(obj))
-


### PR DESCRIPTION
In cci beta77+, the OrgConfig.config dict contains a datetime object to track the created date on a scratch org.  That was causing errors like this one when set_org was called on the keychain:
https://mrbelvedereci-staging.herokuapp.com/builds/207