### PR TITLE
Feature/django up

### DIFF
--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -57,20 +57,20 @@ BUILD_TYPES = (
 
 
 class Build(models.Model):
-    repo = models.ForeignKey('repository.Repository', related_name='builds')
+    repo = models.ForeignKey('repository.Repository', related_name='builds', on_delete=models.CASCADE)
     branch = models.ForeignKey('repository.Branch', related_name='builds',
-                               null=True, blank=True)
+                               null=True, blank=True, on_delete=models.CASCADE)
     commit = models.CharField(max_length=64)
     commit_message = models.TextField(null=True, blank=True)
     tag = models.CharField(max_length=255, null=True, blank=True)
     pr = models.IntegerField(null=True, blank=True)
-    plan = models.ForeignKey('plan.Plan', related_name='builds')
+    plan = models.ForeignKey('plan.Plan', related_name='builds', on_delete=models.CASCADE)
     org = models.ForeignKey('cumulusci.Org', related_name='builds', null=True,
-                            blank=True)
+                            blank=True, on_delete=models.CASCADE)
     org_instance = models.ForeignKey('cumulusci.ScratchOrgInstance',
-                                     related_name='builds', null=True, blank=True)
+                                     related_name='builds', null=True, blank=True, on_delete=models.CASCADE)
     schedule = models.ForeignKey('plan.PlanSchedule', related_name='builds',
-                                 null=True, blank=True)
+                                 null=True, blank=True, on_delete=models.CASCADE)
     log = models.TextField(null=True, blank=True)
     exception = models.TextField(null=True, blank=True)
     error_message = models.TextField(null=True, blank=True)
@@ -83,7 +83,7 @@ class Build(models.Model):
     task_id_run = models.CharField(max_length=64, null=True, blank=True)
     task_id_status_end = models.CharField(max_length=64, null=True, blank=True)
     current_rebuild = models.ForeignKey('build.Rebuild',
-                                        related_name='current_builds', null=True, blank=True)
+                                        related_name='current_builds', null=True, blank=True, on_delete=models.CASCADE)
     time_queue = models.DateTimeField(auto_now_add=True)
     time_start = models.DateTimeField(null=True, blank=True)
     time_end = models.DateTimeField(null=True, blank=True)
@@ -353,9 +353,9 @@ class Build(models.Model):
 
 
 class BuildFlow(models.Model):
-    build = models.ForeignKey('build.Build', related_name='flows')
+    build = models.ForeignKey('build.Build', related_name='flows', on_delete=models.CASCADE)
     rebuild = models.ForeignKey('build.Rebuild', related_name='flows',
-                                null=True, blank=True)
+                                null=True, blank=True, on_delete=models.CASCADE)
     status = models.CharField(max_length=16, choices=BUILD_FLOW_STATUSES,
                               default='queued')
     flow = models.CharField(max_length=255, null=True, blank=True)
@@ -518,10 +518,10 @@ class BuildFlow(models.Model):
 
 
 class Rebuild(models.Model):
-    build = models.ForeignKey('build.Build', related_name='rebuilds')
-    user = models.ForeignKey('users.User', related_name='rebuilds')
+    build = models.ForeignKey('build.Build', related_name='rebuilds', on_delete=models.CASCADE)
+    user = models.ForeignKey('users.User', related_name='rebuilds', on_delete=models.CASCADE)
     org_instance = models.ForeignKey('cumulusci.ScratchOrgInstance',
-                                     related_name='rebuilds', null=True, blank=True)
+                                     related_name='rebuilds', null=True, blank=True, on_delete=models.CASCADE)
     status = models.CharField(max_length=16, choices=BUILD_STATUSES,
                               default='queued')
     exception = models.TextField(null=True, blank=True)

--- a/metaci/cumulusci/models.py
+++ b/metaci/cumulusci/models.py
@@ -16,7 +16,7 @@ class Org(models.Model):
     name = models.CharField(max_length=255)
     json = models.TextField()
     scratch = models.BooleanField(default=False)
-    repo = models.ForeignKey('repository.Repository', related_name='orgs')
+    repo = models.ForeignKey('repository.Repository', related_name='orgs', on_delete=models.CASCADE)
 
     class Meta:
         ordering = ['name', 'repo__owner', 'repo__name']
@@ -52,8 +52,8 @@ class Org(models.Model):
 
 
 class ScratchOrgInstance(models.Model):
-    org = models.ForeignKey('cumulusci.Org', related_name='instances')
-    build = models.ForeignKey('build.Build', related_name='scratch_orgs', null=True, blank=True)
+    org = models.ForeignKey('cumulusci.Org', related_name='instances', on_delete=models.CASCADE)
+    build = models.ForeignKey('build.Build', related_name='scratch_orgs', null=True, blank=True, on_delete=models.CASCADE)
     username = models.CharField(max_length=255)
     sf_org_id = models.CharField(max_length=32)
     deleted = models.BooleanField(default=False)

--- a/metaci/notification/models.py
+++ b/metaci/notification/models.py
@@ -4,22 +4,22 @@ from django.db import models
 
 # Create your models here.
 class PlanNotification(models.Model):
-    user = models.ForeignKey('users.User', related_name='plan_notifications')
-    plan = models.ForeignKey('plan.Plan', related_name='notifications')
+    user = models.ForeignKey('users.User', related_name='plan_notifications', on_delete=models.CASCADE)
+    plan = models.ForeignKey('plan.Plan', related_name='notifications', on_delete=models.CASCADE)
     on_success = models.BooleanField(default=False)
     on_fail = models.BooleanField(default=True)
     on_error = models.BooleanField(default=True)
 
 class BranchNotification(models.Model):
-    user = models.ForeignKey('users.User', related_name='branch_notifications')
-    branch = models.ForeignKey('repository.Branch', related_name='notifications')
+    user = models.ForeignKey('users.User', related_name='branch_notifications', on_delete=models.CASCADE)
+    branch = models.ForeignKey('repository.Branch', related_name='notifications', on_delete=models.CASCADE)
     on_success = models.BooleanField(default=False)
     on_fail = models.BooleanField(default=True)
     on_error = models.BooleanField(default=True)
 
 class RepositoryNotification(models.Model):
-    user = models.ForeignKey('users.User', related_name='repo_notifications')
-    repo = models.ForeignKey('repository.Repository', related_name='notifications')
+    user = models.ForeignKey('users.User', related_name='repo_notifications', on_delete=models.CASCADE)
+    repo = models.ForeignKey('repository.Repository', related_name='notifications', on_delete=models.CASCADE)
     on_success = models.BooleanField(default=False)
     on_fail = models.BooleanField(default=True)
     on_error = models.BooleanField(default=True)

--- a/metaci/plan/models.py
+++ b/metaci/plan/models.py
@@ -126,8 +126,8 @@ SCHEDULE_CHOICES=(
 
 
 class PlanRepository(models.Model):
-    plan = models.ForeignKey(Plan)
-    repo = models.ForeignKey(Repository)
+    plan = models.ForeignKey(Plan, on_delete=models.CASCADE)
+    repo = models.ForeignKey(Repository, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name_plural = 'Plan Repositories'
@@ -137,8 +137,8 @@ class PlanRepository(models.Model):
 
 
 class PlanSchedule(models.Model):
-    plan = models.ForeignKey(Plan)
-    branch = models.ForeignKey('repository.branch')
+    plan = models.ForeignKey(Plan, on_delete=models.CASCADE)
+    branch = models.ForeignKey('repository.branch', on_delete=models.CASCADE)
     schedule = models.CharField(max_length=16, choices=SCHEDULE_CHOICES)
 
     class Meta:

--- a/metaci/repository/models.py
+++ b/metaci/repository/models.py
@@ -31,7 +31,7 @@ class Repository(models.Model):
 
 class Branch(models.Model):
     name = models.CharField(max_length=255)
-    repo = models.ForeignKey(Repository, related_name='branches')
+    repo = models.ForeignKey(Repository, related_name='branches', on_delete=models.CASCADE)
     deleted = models.BooleanField(default=False)
 
     class Meta:

--- a/metaci/testresults/models.py
+++ b/metaci/testresults/models.py
@@ -8,7 +8,7 @@ from metaci.testresults.choices import OUTCOME_CHOICES
 
 class TestClass(models.Model):
     name = models.CharField(max_length=255, db_index=True)
-    repo = models.ForeignKey('repository.Repository', related_name='testclasses')
+    repo = models.ForeignKey('repository.Repository', related_name='testclasses', on_delete=models.CASCADE)
     
     class Meta:
         verbose_name = 'Test Class'
@@ -19,7 +19,7 @@ class TestClass(models.Model):
 
 class TestMethod(models.Model):
     name = models.CharField(max_length=255, db_index=True)
-    testclass = models.ForeignKey(TestClass, related_name='methods')
+    testclass = models.ForeignKey(TestClass, related_name='methods', on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Test Method'
@@ -77,8 +77,8 @@ class TestResultManager(models.Manager):
         return diff
 
 class TestResult(models.Model):
-    build_flow = models.ForeignKey('build.BuildFlow', related_name='test_results')
-    method = models.ForeignKey(TestMethod, related_name='test_results')
+    build_flow = models.ForeignKey('build.BuildFlow', related_name='test_results', on_delete=models.CASCADE)
+    method = models.ForeignKey(TestMethod, related_name='test_results', on_delete=models.CASCADE)
     duration = models.FloatField(null=True, blank=True, db_index=True)
     outcome = models.CharField(max_length=16, choices=OUTCOME_CHOICES, db_index=True)
     stacktrace = models.TextField(null=True, blank=True)

--- a/metaci/users/urls.py
+++ b/metaci/users/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import url
 
 from . import views
 
+app_name='users'
 urlpatterns = [
     url(
         regex=r'^$',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,40 +1,40 @@
  
 
 # Bleeding edge Django
-django==1.10.7
+django==1.11.10
 
 # Configuration
-django-environ==0.4.1
-whitenoise==3.2.2
+django-environ==0.4.4
+whitenoise==3.3.1
 
 
 # Forms
-django-braces==1.10.0
-django-crispy-forms==1.6.1
-django_filter==1.0.4
+django-braces==1.12.0
+django-crispy-forms==1.7.0
+django_filter==1.1.0
 
 # Models
-django-model-utils==2.6
+django-model-utils==3.1.1
 
 # Images
-Pillow==3.4.2
+Pillow==5.0.0
 
 # For user registration, either via email or social
 # Well-built with regular release cycles!
-django-allauth==0.29.0
+django-allauth==0.35.0
 
 
 # Python-PostgreSQL Database Adapter
-psycopg2==2.6.2
+psycopg2==2.7.4
 
 # Unicode slugification
 awesome-slugify==1.6.5
 
 # Time zones support
-pytz==2016.7
+pytz==2018.3
 
 # Redis support
-django-redis==4.6.0
+django-redis==4.9.0
 redis>=2.10.5
 
 # Django RQ
@@ -67,7 +67,7 @@ django-watson>=1.3.0
 honcho>=0.7.1
 
 # Django REST Framework
-djangorestframework==3.6.3
+djangorestframework==3.7.7
 djangorestframework-filters==0.10.2
 
 # Core API for DRF schema generation

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -15,3 +15,5 @@ ipdb==0.10.1
 
 pytest-django==3.1.1
 pytest-sugar==0.7.1
+
+psycopg2-binary

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -12,8 +12,7 @@ gunicorn==19.7.1
 # Static and Media Storage
 # ------------------------------------------------
 boto==2.48.0
-django-storages-redux==1.6.5
-
+django-storages
 
 # Email backends for Mailgun, Postmark, SendGrid and more
 # -------------------------------------------------------

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,17 +7,17 @@
 # WSGI Handler
 # ------------------------------------------------
 gevent==1.2a1
-gunicorn==19.6.0
+gunicorn==19.7.1
 
 # Static and Media Storage
 # ------------------------------------------------
-boto==2.43.0
-django-storages-redux==1.3.2
+boto==2.48.0
+django-storages-redux==1.6.5
 
 
 # Email backends for Mailgun, Postmark, SendGrid and more
 # -------------------------------------------------------
-django-anymail==0.6.1
+django-anymail==1.4
 
 # Raven is the Sentry client
 # --------------------------


### PR DESCRIPTION
upgrade django (and related deps) to latest long term support, django 1.11

added an `on_delete` to all foreign keys that were relying on a default behavior of CASCADE, the default has been deprecated in 1.11

updated urls.py to remove deprecation warnings based on similar changes in the django-cookiecutter template