### PR TITLE
Go back to get_template instead of render_to_string

### DIFF
--- a/metaci/notification/tasks.py
+++ b/metaci/notification/tasks.py
@@ -4,7 +4,7 @@ from django import db
 from django.conf import settings
 from django.core.cache import cache
 from django.core.mail import send_mail
-from django.template.loader import render_to_string
+from django.template.loader import get_template
 from django.template import Context
 from metaci.users.models import User
 from metaci.build.models import Build
@@ -75,13 +75,16 @@ def send_notification_message(build_id, user_id):
         log_lines = build.log.split('\n')
     log_lines = '\n'.join(log_lines[-25:])
 
+    template_txt = get_template('build/email.txt')
+    template_html = get_template('build/email.html')
+
     context = {
         'build': build,
         'log_lines': log_lines,
     }
 
     subject = '[{}] Build #{} of {} {} - {}'.format(build.repo.name, build.id, build.branch.name, build.plan.name, build.get_status().upper())
-    message = render_to_string('build/email.txt', context)
-    html_message = render_to_string('build/email.html', context)
+    message = template_txt.render(context)
+    html_message = template_html.render(context)
 
     return send_mail(subject, message, settings.FROM_EMAIL, [user.email], html_message=html_message)


### PR DESCRIPTION
Apparently render_to_string isn't as easily substituted for get_template/render as I thought. I ran into this:

```
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python2.7/site-packages/rq/worker.py", line 713, in perform_job
    rv = job.perform()
  File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 558, in perform
    self._result = self._execute()
  File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 564, in _execute
    return self.func(*self.args, **self.kwargs)
  File "/app/metaci/notification/tasks.py", line 87, in send_notification_message
    return send_mail(subject, message, settings.FROM_EMAIL, [user.email], html_message=html_message)
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/mail/__init__.py", line 56, in send_mail
    fail_silently=fail_silently,
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/mail/__init__.py", line 36, in get_connection
    klass = import_string(backend or settings.EMAIL_BACKEND)
  File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/module_loading.py", line 27, in import_string
    six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
  File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/module_loading.py", line 23, in import_string
    return getattr(module, class_name)
ImportError: Module "anymail.backends.sendgrid" does not define a "SendGridBackend" attribute/class
```