### PR TITLE
resurrect soft-deleted branch for new builds

### DIFF
--- a/metaci/plan/forms.py
+++ b/metaci/plan/forms.py
@@ -67,6 +67,10 @@ class RunPlanForm(forms.Form):
             repo=self.repo,
             name=self.cleaned_data['branch'],
         )
+        if branch.is_removed:
+            # resurrect the soft deleted branch
+            branch.is_removed = False
+            branch.save()
             
         keep_org = self.cleaned_data.get('keep_org')
 

--- a/metaci/repository/views.py
+++ b/metaci/repository/views.py
@@ -180,6 +180,10 @@ def github_push_webhook(request):
 
     if branch_name:
         branch, created = Branch.objects.get_or_create(repo=repo, name=branch_name)
+        if branch.is_removed:
+            # resurrect the soft deleted branch
+            branch.is_removed = False
+            branch.save()
 
     for plan in repo.plans.filter(type__in=['commit', 'tag'], active=True):
         run_build, commit, commit_message = plan.check_push(push)


### PR DESCRIPTION
We reuse branch objects already, but since https://github.com/SalesforceFoundation/MetaCI/pull/214 those branches could be in a soft-deleted state. This resets that state when a deleted branch is used in a new build.