### PR TITLE
Remove handle_orphaned_builds from postdeploy

### DIFF
--- a/postdeploy.sh
+++ b/postdeploy.sh
@@ -1,2 +1,1 @@
 python manage.py migrate --noinput
-python manage.py handle_orphaned_builds


### PR DESCRIPTION
Not working as expected, just want to remove it until we get it figured out. Can still be run manually with one-off dyno.