### PR TITLE
Handle robot test output files in the app root directory

### DIFF
--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -230,7 +230,7 @@ class Build(models.Model):
                     flow=flow,
                 )
                 build_flow.save()
-                build_flow.run(project_config, org_config, self)
+                build_flow.run(project_config, org_config, self.root_dir)
 
                 if build_flow.status != 'success':
                     self.logger = init_logger(self)
@@ -414,8 +414,8 @@ class BuildFlow(models.Model):
         if self.log:
             return format_log(self.log)
 
-    def run(self, project_config, org_config, build):
-        self.build_instance = build
+    def run(self, project_config, org_config, root_dir):
+        self.root_dir = root_dir
         # Record the start
         set_build_info(self, status='running', time_start=timezone.now())
 
@@ -497,7 +497,7 @@ class BuildFlow(models.Model):
         has_results = False
 
         root_dir_robot_path = '{}/output.xml'.format(
-            self.build_instance.root_dir,
+            self.root_dir,
         )
         # Load robotframework's output.xml if found
         if os.path.isfile('output.xml'):

--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -194,6 +194,7 @@ class Build(models.Model):
         try:
             # Extract the repo to a temp build dir
             self.build_dir = self.checkout()
+            self.root_dir = os.getcwd()
 
             # Change directory to the build_dir
             os.chdir(self.build_dir)
@@ -229,7 +230,7 @@ class Build(models.Model):
                     flow=flow,
                 )
                 build_flow.save()
-                build_flow.run(project_config, org_config)
+                build_flow.run(project_config, org_config, self)
 
                 if build_flow.status != 'success':
                     self.logger = init_logger(self)
@@ -413,7 +414,8 @@ class BuildFlow(models.Model):
         if self.log:
             return format_log(self.log)
 
-    def run(self, project_config, org_config):
+    def run(self, project_config, org_config, build):
+        self.build_instance = build
         # Record the start
         set_build_info(self, status='running', time_start=timezone.now())
 
@@ -494,10 +496,21 @@ class BuildFlow(models.Model):
     def load_test_results(self):
         has_results = False
 
+        root_dir_robot_path = '{}/output.xml'.format(
+            self.build_instance.root_dir,
+        )
         # Load robotframework's output.xml if found
         if os.path.isfile('output.xml'):
             has_results = True
             import_robot_test_results(self, 'output.xml')
+
+        elif os.path.isfile(root_dir_robot_path):
+            # FIXME: Not sure why robot stopped writing into the cwd
+            # (build temp dir) but this should handle it so long as
+            # only one build runs at a time
+            has_results = True
+            import_robot_test_results(self, root_dir_robot_path)
+            os.remove(root_dir_robot_path)
 
         # Load JUnit
         results = []

--- a/metaci/testresults/importer.py
+++ b/metaci/testresults/importer.py
@@ -222,4 +222,5 @@ def render_robot_test_xml(root, test):
         suite.append(test['suite']['teardown'])
     suite.append(test['suite']['status'])
     test_xml = ET.tostring(testroot)
-    return re.sub(r'sid=.*<', 'sid=<masked>', test_xml)
+    return re.sub(r'sid=.*<', 'sid=MASKED<', test_xml)
+    


### PR DESCRIPTION
Not certain why this is necessary yet, but it does work on my local instance and should fix the same issue in staging