### PR TITLE
Feature/prviews

### DIFF
--- a/metaci/plan/models.py
+++ b/metaci/plan/models.py
@@ -133,7 +133,7 @@ class PlanRepository(models.Model):
     class Meta:
         ordering = ['repo', 'plan']
         verbose_name_plural = 'Plan Repositories'
-        unique_together = ('plan', 'repo')
+        #unique_together = ('plan', 'repo')
 
     def __unicode__(self):
         return u'[{}] {}'.format(self.repo, self.plan)

--- a/metaci/plan/models.py
+++ b/metaci/plan/models.py
@@ -133,9 +133,20 @@ class PlanRepository(models.Model):
     class Meta:
         ordering = ['repo', 'plan']
         verbose_name_plural = 'Plan Repositories'
+        unique_together = ('plan', 'repo')
 
     def __unicode__(self):
         return u'[{}] {}'.format(self.repo, self.plan)
+
+    def get_absolute_url(self):
+        return reverse(
+            "plan_detail_repo",
+            kwargs={
+                "plan_id": self.plan.id,
+                "repo_owner": self.repo.owner,
+                "repo_name": self.repo.name,
+            },
+        )
 
 
 class PlanSchedule(models.Model):

--- a/metaci/plan/templates/plan/detail.html
+++ b/metaci/plan/templates/plan/detail.html
@@ -54,6 +54,27 @@
   <p>{{ plan.description }}</p>
 </div>
 {% endif %}
+
+<table class="slds-table slds-table--bordered slds-table--cell-buffer">
+  <thead>
+    <tr class="slds-text-title--caps">
+
+      <th scope="col">
+        <div class="slds-truncate" title="">Repository</div>
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+      {% for pr in plan.planrepository_set.all %}
+      <tr>
+        <th data-label="Repository">
+          <div class="slds-truncate" title="{{ pr.repo.name }}"><a href="{{ pr.get_absolute_url }}">{{ pr.repo.name }}</a></div>
+        </th>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
 <table class="slds-table slds-table--bordered slds-table--cell-buffer">
   <thead>
     <tr class="slds-text-title--caps">

--- a/metaci/plan/templates/plan/plan_repo_detail.html
+++ b/metaci/plan/templates/plan/plan_repo_detail.html
@@ -1,0 +1,114 @@
+{% extends 'layout_full.html' %}
+
+{% block layout_parent_link %}<a href="/builds">Builds</a>{% endblock %}
+
+{% block layout_header_text %}Latest Builds for {{ plan.name }}: {{ repo.name }}{% endblock %}
+
+{% block layout_header_details %}
+  <ul class="slds-grid slds-page-header__detail-row">
+  
+    <li class="slds-page-header__detail-block">
+      <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Repository">Repository</p>
+      <p class="slds-text-body--regular slds-truncate" title="{{ repo.name }}">
+        <a href="{{repo.get_absolute_url}}">{{ repo.name }}</a>
+      </p>
+    </li>
+    <li class="slds-page-header__detail-block">
+      <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Type">Type</p>
+      <p class="slds-text-body--regular slds-truncate" title="{{ plan.type }}">
+        {{ plan.type }}
+      </p>
+    </li>
+    <li class="slds-page-header__detail-block">
+      <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Regex">Regex</p>
+      <p class="slds-text-body--regular slds-truncate" title="{{ plan.regex }}">
+        {{ plan.regex }}
+      </p>
+    </li>
+    <li class="slds-page-header__detail-block">
+      <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Org">Org</p>
+      <p class="slds-text-body--regular slds-truncate" title="{{ plan.org }}">
+        {{ plan.org }}
+      </p>
+    </li>
+    <li class="slds-page-header__detail-block">
+      <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Flows">Flows</p>
+      <p class="slds-text-body--regular slds-truncate" title="{{ plan.flows }}">
+        {{ plan.flows }}
+      </p>
+    </li>
+    <li class="slds-page-header__detail-block">
+      <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Active?">Active?</p>
+      <p class="slds-text-body--regular slds-truncate slds-badge {% if plan.active %}slds-theme--success{% else %}slds-theme--error{% endif %}"
+        title="{{ build.get_status }}" title="{{ plan.active }}">
+        {{ plan.active }}
+      </p>
+    </li>
+  </ul>
+{% endblock %}
+
+{% block layout_header_buttons %}
+      <a href="{{ planrepo.get_absolute_url }}/run">
+        <button class="slds-button slds-button--neutral slds-button--last">
+          Run
+        </button>
+      </a>
+{% endblock %}
+
+{% block layout_body %}
+{% if plan.description %}
+<div class="slds-box">
+  <h3 class="slds-heading slds-heading--large">Description</h3>
+  <p>{{ plan.description }}</p>
+</div>
+{% endif %}
+<table class="slds-table slds-table--bordered slds-table--cell-buffer">
+  <thead>
+    <tr class="slds-text-title--caps">
+      <th scope="col">
+        <div class="slds-truncate" title="">#</div>
+      </th>
+      <th scope="col">
+        <div class="slds-truncate" title="">Status</div>
+      </th>
+      <th scope="col">
+        <div class="slds-truncate" title="">Commit</div>
+      </th>
+      <th scope="col">
+        <div class="slds-truncate" title="">Branch/Tag</div>
+      </th>
+      <th scope="col">
+        <div class="slds-truncate" title="">Start Date</div>
+      </th>
+      <th scope="col">
+        <div class="slds-truncate" title="">End Date</div>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for build in builds %}
+    <tr>
+      <th data-label="Build Number">
+        <div class="slds-truncate" title="{{ build.id }}"><a href="/builds/{{ build.id }}">{{ build.id }}</a></div>
+      </th>
+      <td data-label="Status">
+        <div class="slds-truncate slds-badge {% if build.get_status == 'fail' or build.get_status == 'error' %}slds-theme--error{% elif build.get_status == 'success' %}slds-theme--success{% endif %}" title="{{ build.get_status }}">{{ build.get_status }}</div>
+      </td>
+      <td data-label="Commit">
+        <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
+      </td>
+      <td data-label="Branch">
+        <div class="slds-truncate" title="{{ build.branch.name }}">{{ build.branch.name }}</div>
+      </td>
+      <td data-label="Start Date">
+        <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
+      </td>
+      <td data-label="End Date">
+        <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% include 'build/build_pagination.html' %}
+{% endblock %}

--- a/metaci/plan/templates/plan/run_select_repo.html
+++ b/metaci/plan/templates/plan/run_select_repo.html
@@ -11,7 +11,7 @@ Select repository to run plan {{ plan.id }} "{{ plan.name }}"
 
   <div>
     <ul>
-{% for repo in plan.get_repos %}
+{% for repo in repos %}
       <li>
         <a href="/plans/{{ plan.id }}/{{ repo.owner }}/{{ repo.name }}/run/">
           {{ repo.owner }}/{{ repo.name }}

--- a/metaci/plan/urls.py
+++ b/metaci/plan/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
         name='plan_detail',
     ),
     url(
-        r'^(?P<plan_id>\w+)/(?P<repo_owner>[\w-]+)/(?P<repo_name>[\w-]+)/$',
+         r'^(?P<plan_id>\w+)/(?P<repo_owner>[\w-]+)/(?P<repo_name>[\w-]+)$',
         views.plan_detail_repo,
         name='plan_detail_repo',
     ),

--- a/metaci/plan/views.py
+++ b/metaci/plan/views.py
@@ -38,21 +38,22 @@ def plan_detail_repo(request, plan_id, repo_owner, repo_name):
     query = {'id': plan_id}
     if not request.user.is_staff:
         query['public'] = True
-    plan = get_object_or_404(Plan, **query)
-    repo = get_object_or_404(Repository, owner=repo_owner, name=repo_name)
-    query = {'plan': plan, 'repo': repo}
+    planrepo = get_object_or_404(PlanRepository, repo__owner=repo_owner, repo__name=repo_name, plan__id=plan_id)
+    query = {'plan': planrepo.plan, 'repo': planrepo.repo}
     builds = view_queryset(request, query)
 
     context = {
         'builds': builds,
-        'plan': plan,
+        'plan': planrepo.plan,
+        'planrepo': planrepo,
+        'repo': planrepo.repo
     }
-    return render(request, 'plan/detail.html', context=context)
+    return render(request, 'plan/plan_repo_detail.html', context=context)
 
 @staff_member_required
 def plan_run(request, plan_id):
     plan = get_object_or_404(Plan, id=plan_id)
-    context = {'plan': plan}
+    context = {'plan': plan, 'repos': plan.repos}
     return render(request, 'plan/run_select_repo.html', context=context)
 
 @staff_member_required

--- a/metaci/repository/templates/repository/repo_plans.html
+++ b/metaci/repository/templates/repository/repo_plans.html
@@ -50,10 +50,11 @@
         </tr>
       </thead>
       <tbody>
-      {% for plan in repo.plans.all %}
+      {% for planrepo in repo.planrepository_set.all %}
+      {% with plan=planrepo.plan %}
         <tr>
           <th data-label="Plan">
-            <div class="slds-truncate" title="{{ plan.name }}"><a href="{{ plan.get_absolute_url }}">{{ plan.name }}</a></div>
+            <div class="slds-truncate" title="{{ plan.name }}"><a href="{{ planrepo.get_absolute_url }}">{{ plan.name }}</a></div>
           </th>
           <th data-label="Type">
             <div class="slds-truncate"><span>{{ plan.type }}</span></div>
@@ -71,6 +72,7 @@
             <div class="slds-truncate"><span>{{ plan.active }}</span></div>
           </th>
         </tr>
+      {% endwith %}
       {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
I created a separate template for plan_repo_detail, to display just the details of that specific plan/repo combination. I made sure this is whats linked off of the Plans listview on the repo detail, and added a repo list to the plan detail. If you navigate to a repo, its plans, and then go to run a plan, you no longer have to select the repo a second time.