### PR TITLE
Fix Plan Run functionality after recent change which was incorrectly

### DIFF
--- a/metaci/plan/views.py
+++ b/metaci/plan/views.py
@@ -53,7 +53,7 @@ def plan_detail_repo(request, plan_id, repo_owner, repo_name):
 @staff_member_required
 def plan_run(request, plan_id):
     plan = get_object_or_404(Plan, id=plan_id)
-    context = {'plan': plan, 'repos': plan.repos}
+    context = {'plan': plan, 'repos': plan.repos.all()}
     return render(request, 'plan/run_select_repo.html', context=context)
 
 @staff_member_required


### PR DESCRIPTION
passing ManyRelatedManager instead of a queryset from the manager