### PR TITLE
Make it simpler to run a plan against multiple orgs

### DIFF
--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -334,9 +334,14 @@ class Build(models.Model):
     def get_org(self, project_config, retries=3):
         self.logger = init_logger(self)
         attempt = 1
+        if self.org:
+            # If the build's org was already set, keep using it
+            org_name = self.org.name
+        else:
+            org_name = self.plan.org
         while True:
             try:
-                org_config = project_config.keychain.get_org(self.plan.org)
+                org_config = project_config.keychain.get_org(org_name)
                 break
             except ScratchOrgException as e:
                 if (

--- a/metaci/plan/forms.py
+++ b/metaci/plan/forms.py
@@ -18,10 +18,11 @@ class RunPlanForm(forms.Form):
     keep_org = forms.BooleanField(required=False)
     release = forms.ModelChoiceField(None, required=False)
 
-    def __init__(self, plan, repo, user, *args, org=None, **kwargs):
+    def __init__(self, plan, repo, user, *args, **kwargs):
         self.plan = plan
         self.repo = repo
         self.user = user
+        org = kwargs.pop('org', None)
         self.org = org
         super(RunPlanForm, self).__init__(*args, **kwargs)
         self.fields['branch'].choices = self._get_branch_choices()

--- a/metaci/plan/forms.py
+++ b/metaci/plan/forms.py
@@ -41,7 +41,6 @@ class RunPlanForm(forms.Form):
             ),
         )
         if self.advanced_mode:
-            self.fields['keep_org'].widget = forms.HiddenInput()
             self.helper.layout.extend([
                 Fieldset(
                     'Keep org? (scratch orgs only)',

--- a/metaci/plan/forms.py
+++ b/metaci/plan/forms.py
@@ -18,10 +18,11 @@ class RunPlanForm(forms.Form):
     keep_org = forms.BooleanField(required=False)
     release = forms.ModelChoiceField(None, required=False)
 
-    def __init__(self, plan, repo, user, *args, **kwargs):
+    def __init__(self, plan, repo, user, *args, org=None, **kwargs):
         self.plan = plan
         self.repo = repo
         self.user = user
+        self.org = org
         super(RunPlanForm, self).__init__(*args, **kwargs)
         self.fields['branch'].choices = self._get_branch_choices()
         self.fields['release'].queryset = self.repo.releases
@@ -103,6 +104,7 @@ class RunPlanForm(forms.Form):
         build = Build(
             repo=self.repo,
             plan=self.plan,
+            org=self.org,
             branch=branch,
             commit=commit,
             keep_org=keep_org,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,7 +39,7 @@ django-rq-wrapper>=1.4
 django-rq-scheduler>=1.1.1
 
 # CumulusCI
-cumulusci==2.1.0b1
+cumulusci==2.1.1b1
 
 # Salesforce Lightning Design System for Django
 django-slds


### PR DESCRIPTION
Make it possible to preset the org for a build when the build is constructed. Still defaults to fetching it from the plan when the build starts.